### PR TITLE
Merge fixes for DivideByZero errors

### DIFF
--- a/VRSL_GPUReadBack.cs
+++ b/VRSL_GPUReadBack.cs
@@ -36,6 +36,19 @@ namespace VRSL{
             currentTime = 0.0f;
             output = new Color[texture.width * texture.height];
             SendCustomEventDelayedSeconds("_StartGPUReadback",startDelay);
+
+            // Sanity check all connected Readback Functions to see if they are enabled
+            // so if we try to update them they will have proper variable states
+            VRSL_ReadBackFunction rb;
+            for(int i = 0; i < functionReaders.Length; i++)
+            {
+                rb = functionReaders[i];
+                if(rb.gameObject.activeSelf == false) {
+                    Debug.LogWarning($"Found a GPU-Readback function that was not enabled! (Index {i})\nTemporarily enabling it for initialization...");
+                    rb.gameObject.SetActive(true); // Set to true so Start event fires
+                    rb.gameObject.SetActive(false); // Revert to disabled state
+                }
+            }
         }
 
         void Update()

--- a/VRSL_GPUReadBack.cs
+++ b/VRSL_GPUReadBack.cs
@@ -103,7 +103,7 @@ namespace VRSL{
     public class VRSL_GPUReadBack_Editor : Editor
     {
         public static Texture logo;
-        public static string ver = "VRSL GPUReadback ver:" + " <b><color=#6a15ce> 1.0</color></b>";
+        public static string ver = "VRSL GPUReadback ver:" + " <b><color=#6a15ce> 1.1</color></b>";
          SerializedProperty functionReaders;
         void OnEnable()
         {

--- a/VRSL_ReadBackFunction.cs
+++ b/VRSL_ReadBackFunction.cs
@@ -667,6 +667,17 @@ namespace VRSL{
             Color[] pixelData = reader.output;
             int startindex = 0;
             int index, xOffset, yOffset;
+
+            // Sanity check width and rowSize to see if they are not zero.
+            // If they are zero, then the Start event was never fired, likely
+            // from the object being disabled upon world load. This causes
+            // a DivideByZero error that the Unity editor's UDON exception handler
+            // catches, but the in-game one does not, resulting in VRChat hard crashing
+            if(width == 0 || rowSize == 0) {
+                Debug.LogError("VRSL-GPUReadback Function had width or rowSize of 0. This would cause divde by zero errors! Start() event was not executed.\nWas this object disabled on world load?");
+                return;
+            }
+
             if(reader.extendedUniverseMode)
             {       
                 for(int i = 0; i < Mathf.Min(Mathf.Max(size, 1), 512); i++)


### PR DESCRIPTION
Added some catches and checks to both main scripts to prevent DivideByZero errors if the readback functions aren't initialized properly.

Tested in a simple scene with 2 Readback functions toggling gameobjects attached to 1 GPUReadback root script. After connecting them all up we purposfully disable the gameobject of one of them before hitting the play button.

GPUReadback notices this and temporarily enables it so the `Start` event can execute on the readback function script.

If this fails, the readback function now has a catch in it to check a couple variabled for a valid initialization, if they aren't initialized it will return early when executing `_GetData` to change the output states.